### PR TITLE
HBSD: Provide new Tor Onion Service v3 Nodes for HardenedBSD

### DIFF
--- a/master.csv
+++ b/master.csv
@@ -109,8 +109,11 @@ tech and software,,DEF CON Groups,http://jrw32khnmfehvdsvwdf34mywoqj5emvxh4mzbkl
 tech and software,,DEF CON Home,http://g7ejphhubv5idbbu3hb3wawrs5adw7tkx7yjabnf65xtzztgg4hcsqqd.onion/,https://www.facebook.com/defcon/posts/i-am-proud-to-announce-the-v3-onion-address-for-def-condefconorg-main-web-siteht/10155438526096656/,
 tech and software,,DEF CON Media,http://m6rqq6kocsyugo2laitup5nn32bwm3lh677chuodjfmggczoafzwfcad.onion/,https://www.facebook.com/defcon/posts/i-am-proud-to-announce-the-v3-onion-address-for-def-condefconorg-main-web-siteht/10155438526096656/,
 tech and software,,ExpressVPN,http://expressobutiolem.onion/,https://www.expressvpn.com/blog/expressvpn-launches-tor-onion/,
-tech and software,y,Hardened BSD,http://3jkjhrvkdbdkqisnwhdpe4afh2j2g3suhsfcewiemsyk5ecd6gadmxyd.onion/,https://hardenedbsd.org/article/shawn-webb/2017-03-11/hardenedbsd-through-tor-hidden-service,
-tech and software,y,Hardened BSD,http://dxsj6ifxytlgq33k.onion/,https://hardenedbsd.org/article/shawn-webb/2017-03-11/hardenedbsd-through-tor-hidden-service,
+tech and software,,HardenedBSD,http://lkiw4tmbudbr43hbyhm636sarn73vuow77czzohdbqdpjuq3vdzvenyd.onion/,https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes
+tech and software,,HardenedBSD git-01.md.hardenedbsd.org,http://dacxzjk3kq5mmepbdd3ai2ifynlzxsnpl2cnkfhridqfywihrfftapid.onion/,https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes
+tech and software,,HardenedBSD ci-01.nyi.hardenedbsd.org,http://qspcqclhifj3tcpojsbwoxgwanlo2wakti2ia4wozxjcldkxmw2yj3yd.onion/,https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes
+tech and software,,HardenedBSD ci-03.md.hardenedbsd.org,http://eqvnohly4tjrkpwatdhgptftabpesofirnhz5kq7jzn4zd6ernpvnpqd.onion/,https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes
+tech and software,,HardenedBSD ci-04.md.hardenedbsd.org,http://rfqabq2w65nhdkukeqwf27r7h5xfh53h3uns6n74feeyl7s5fbjxczqd.onion/,https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes
 tech and software,,keybase.io,http://keybase5wmilwokqirssclfnsqrjdsi7jdir5wy7y7iu3tanwmtp6oid.onion/,https://keybase.io/docs/command_line/tor,
 tech and software,,Mailpile,http://clgs64523yi2bkhz.onion/,https://www.mailpile.is,
 tech and software,,OnionShare,http://lldan5gahapx5k7iafb3s4ikijc4ni7gx5iywdflkba5y2ezyg6sjgyd.onion/,https://onionshare.org/,


### PR DESCRIPTION
HardenedBSD has revamped its infrastructure. The old nodes were retired
prior to the migration to the new nodes. This commit removes the
new-defunct old nodes in favor of thew new ones.

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>
Reference:	https://hardenedbsd.org/article/shawn-webb/2020-01-30/hardenedbsd-tor-onion-service-v3-nodes